### PR TITLE
Revert "Periodservice cycles"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: java
 jdk: oraclejdk8
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 notifications:
   slack:
     on_success: change

--- a/src/main/java/bisq/desktop/main/dao/proposal/dashboard/ProposalDashboardView.java
+++ b/src/main/java/bisq/desktop/main/dao/proposal/dashboard/ProposalDashboardView.java
@@ -141,13 +141,12 @@ public class ProposalDashboardView extends ActivatableView<GridPane, Void> {
 
     private void onChainHeightChanged(int height) {
         phaseBarsItems.forEach(item -> {
-            int startBlock = periodService.getFirstBlockOfPhase(periodService.getCycle(height), item.getPhase());
-            int endBlock = periodService.getLastBlockOfPhase(periodService.getCycle(height), item.getPhase());
+            int startBlock = periodService.getAbsoluteStartBlockOfPhase(height, item.getPhase());
+            int endBlock = periodService.getAbsoluteEndBlockOfPhase(height, item.getPhase());
             item.setStartAndEnd(startBlock, endBlock);
             double progress = 0;
             if (height >= startBlock && height <= endBlock) {
-                progress = (double) (height - startBlock + 1) /
-                        (double) periodService.getCycle(height).getPhaseDuration(item.getPhase());
+                progress = (double) (height - startBlock + 1) / (double) item.getPhase().getDurationInBlocks();
             } else if (height < startBlock) {
                 progress = 0;
             } else if (height > endBlock) {


### PR DESCRIPTION
Reverts ManfredKarrer/bisq-desktop#1

Tested with both old version and complete new setup (new genesis and new apps) but in both cases there are plenty of issues. Also as discussed we might move that data structure to the blocks directly so that would change again quite a bit. As the current version works without known bugs I will revert that PR and build on top of the existing version and move to the new data structure. 